### PR TITLE
feat: Add data search API, pagination

### DIFF
--- a/apps/templates/apps/data_detail.html
+++ b/apps/templates/apps/data_detail.html
@@ -1,10 +1,8 @@
 <!DOCTYPE html>
 {% load static %}
-
 <html lang="ko">
 
 <head>
-    <link rel="stylesheet" href="{% static 'css/navbar.css' %}"/>
     <meta charset="UTF-8"/>
     <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
@@ -27,9 +25,9 @@
     <!-- 아이콘을 고해상도 png파일로 띄울 때 link로 -->
     <!-- 따로 링크를 걸어놓지 않으면 프로젝트의 루트 경로에서 favicon.ico를 찾아서 자동으로 띄움 -->
     <!--  <link rel="icon" href="./favicon.png" />-->
+
     <!-- reset css -->
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/reset-css@5.0.1/reset.min.css"/>
-
     <!-- 폰트 불러오기(google font) -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -39,39 +37,30 @@
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 
     <!-- main.css는 가급적 맨 밑에 위치하게 함 -->
-    <link rel="stylesheet" href="../CSS/common.css"/>
-    <link rel="stylesheet" href="../CSS/main.css"/>
+    <link rel="stylesheet" href="{% static 'css/navbar.css' %}"/>
 
 
     <!-- defer : html이 준비가 되면 그때 실행 -->
-    <script defer src="../js/common.js"></script>
-    <script defer src="../js/main.js"></script>
+    <script defer src="./js/common.js"></script>
+    <script defer src="./js/main.js"></script>
 </head>
 
 <body>
 {% include 'apps/navbar.html' %}
-{% for data in posts %}
-    <hr/>
-    <span>data id: {{ data.data_id }}</span>
-    <h2><a href="{{ data.data_id }}">{{ data.title }}</a></h2>
-    <h3>{{ data.des }}</h3>
-    <h4>{{ data.type }}</h4>
-    <h4>{{ data.ori_source }}</h4>
-    <h4>{{ data.label }}</h4>
-{% endfor %}
 
+<h2>title: {{ data.title }}</h2>
 <br>
-{% if posts.has_previous %}
-    <a href="?page=1">맨 앞으로</a>
-    <a href="?page={{ posts.previous_page_number }}">이전으로</a>
-{% endif %}
-<span>{{ posts.number }}</span>
-<span>/</span>
-<span>{{ posts.paginator.num_pages }}</span>
-{% if posts.has_next %}
-    <a href="?page={{ posts.next_page_number }}">다음으로</a>
-    <a href="?page={{ posts.paginator.num_pages }}">맨 뒤로</a>
-{% endif %}
+<p>des: {{ data.des }}</p>
+<br>
+<p>url: {{ data.url }}</p>
+<br>
+<p>type: {{ data.type }}</p>
+<br>
+<p>source: {{ data.source }}</p>
+<br>
+<p>ori_source: {{ data.ori_source }}</p>
+<br>
+<p>label: {{ data.label }}</p>
 
 <!-- VISUAL -->
 

--- a/apps/templates/apps/search_detail.html
+++ b/apps/templates/apps/search_detail.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 {% load static %}
+
 <html lang="ko">
 
 <head>
@@ -49,8 +50,31 @@
 
 <body>
     {% include 'apps/navbar.html' %}
+    <div>
+        {% for data in posts %}
+            <table>
+                <tr>
+                    <td>{{ data.data_id }}</td>
+                    <td>{{ data.title }}</td>
+                </tr>
+            </table>
+        {% endfor %}
 
-<!-- VISUAL -->
+        {% if posts.has_previous %}
+        <a href="?page=1">맨 앞으로</a>
+        <a href="?page={{ posts.previous_page_number }}">이전으로</a>
+        {% endif %}
+        <span>{{ posts.number }}</span>
+        <span>/</span>
+        <span>{{ posts.paginator.num_pages }}</span>
+        {% if posts.has_next %}
+        <a href="?page={{ posts.next_page_number }}">다음으로</a>
+        <a href="?page={{ posts.paginator.num_pages }}">맨 뒤로</a>
+        {% endif %}
+
+    </div>
+
+    <!-- VISUAL -->
 
 </body>
 

--- a/apps/urls.py
+++ b/apps/urls.py
@@ -11,6 +11,7 @@ urlpatterns = [
     path('logout/', views.logout),
     path('search/category/', views.search_category),
     path('search/detail/', views.search_detail),
+    path('search/detail/<int:pk>/', views.data_detail),
     path('profile/', views.profile),
     path('community/', views.community),
     path('community/create', views.community_create),

--- a/apps/views.py
+++ b/apps/views.py
@@ -1,7 +1,7 @@
 from django.shortcuts import render, redirect
 import bcrypt, re
 from django.http import JsonResponse, HttpResponse
-from .models import User
+from .models import User, Data, DataPlatform
 
 from django.contrib.sites.shortcuts import get_current_site
 from django.utils.http import urlsafe_base64_encode,urlsafe_base64_decode
@@ -12,9 +12,7 @@ from django.utils.encoding import force_str
 from .text import message
 from django.views import View
 from django.core.exceptions import ValidationError
-from django.contrib import auth
-from django.contrib.auth import authenticate
-
+from django.core.paginator import Paginator
 
 import environ
 env = environ.Env()
@@ -91,9 +89,18 @@ def search_category(request):
     )
 
 def search_detail(request):
+    data = Data.objects
+    data_list = Data.objects.all()
+    paginator = Paginator(data_list, 20)
+    page = request.GET.get('page')
+    posts = paginator.get_page(page)
     return render(
         request,
-        'apps/search_detail.html'
+        'apps/search_detail.html',
+        {
+            'data': data,
+            'posts': posts
+        }
     )
 
 def profile(request):

--- a/apps/views.py
+++ b/apps/views.py
@@ -89,19 +89,30 @@ def search_category(request):
     )
 
 def search_detail(request):
-    data = Data.objects
-    data_list = Data.objects.all()
-    paginator = Paginator(data_list, 20)
+    data_list = Data.objects.all().order_by('pk')
+    paginator = Paginator(data_list, 5)
     page = request.GET.get('page')
     posts = paginator.get_page(page)
     return render(
         request,
         'apps/search_detail.html',
         {
-            'data': data,
+            'data': data_list,
             'posts': posts
         }
     )
+
+def data_detail(request, pk):
+    data = Data.objects.get(pk=pk)
+
+    return render(
+        request,
+        'apps/data_detail.html',
+        {
+            'data': data,
+        }
+    )
+
 
 def profile(request):
     return render(


### PR DESCRIPTION
- 데이터 조회 API 구현
- 데이터 조회 시 Pagination 구현
- 코드 작성에 참고한 사이트
  - [Django documentation - Pagination](https://docs.djangoproject.com/en/4.1/topics/pagination/)
  - [티스토리 블로그: Pagination을 알아보자](https://ssungkang.tistory.com/entry/Django-11-Pagination-%EC%9D%84-%EC%95%8C%EC%95%84%EB%B3%B4%EC%9E%90)

2023-02-01 21:34 내용 추가
- pagination 값 5로 수정
- 데이터 상세 페이지(data_detail.html) 추가
- 데이터 상세 뷰(data_detail) 추가
- 데이터 목록 id 값 기준으로 정렬
- 목록에서 제목 링크 클릭 후 상세 페이지로 넘어갈 수 있도록 기능 추가
- 상세 페이지에서 각 데이터의 정보를 조회해서 표시